### PR TITLE
Additional attributes

### DIFF
--- a/lib/sdb_lock.rb
+++ b/lib/sdb_lock.rb
@@ -45,14 +45,15 @@ class SdbLock
   # Try to lock resource_name
   #
   # @param [String] resource_name name to lock
+  # @param [Array] additional_attributes include additional attributes
   # @return [TrueClass] true when locked, unless false
-  def try_lock(resource_name)
+  def try_lock(resource_name, additional_attributes = [])
     attributes = [
       {
         name: LOCK_TIME,
         value: format_time(Time.now)
       }
-    ]
+    ].concat(additional_attributes)
 
     @sdb.put_attributes(
       domain_name: @domain_name,
@@ -79,10 +80,11 @@ class SdbLock
   # It blocks until lock is succeeded.
   #
   # @param [String] resource_name
-  def lock(resource_name)
+  # @param [Array] additional_attributes include additional attributes
+  def lock(resource_name, additional_attributes = [])
     wait_secs = 0.5
     while true
-      lock = try_lock(resource_name)
+      lock = try_lock(resource_name, additional_attributes)
       break if lock
       sleep([wait_secs, MAX_WAIT_SECS].min)
       wait_secs *= 2

--- a/test/test_lock.rb
+++ b/test/test_lock.rb
@@ -36,4 +36,25 @@ class LockTest < MiniTest::Test
     threads.each { |thread| thread.join }
     assert_equal(10, shared_var)
   end
+
+  def test_additional_attributes
+    additional_attributes = [
+      {
+        name: 'additional_attribute',
+        value: 'test'
+      }
+    ]
+
+    # Additional attributes were set
+    @lock.lock("test", additional_attributes)
+    attributes = @lock.send(:item, "test")
+    attributes.each do |a|
+      assert_equal('test', a.value) if a.name == 'additional_attribute'
+    end
+
+    # Additional attributes were unset
+    @lock.unlock("test")
+    attributes = @lock.send(:item, "test")
+    assert_equal([], attributes)
+  end
 end

--- a/test/test_lock.rb
+++ b/test/test_lock.rb
@@ -45,16 +45,23 @@ class LockTest < MiniTest::Test
       }
     ]
 
-    # Additional attributes were set
     @lock.lock("test", additional_attributes)
+    # Checking the values of an attribute are not always immediately available,
+    # so sleep for a second.
+    sleep(1)
     attributes = @lock.send(:item, "test")
-    attributes.each do |a|
-      assert_equal('test', a.value) if a.name == 'additional_attribute'
+    value = attributes.each do |a|
+      break a.value if a.name == 'additional_attribute'
     end
+    # Additional attributes were set
+    assert_equal('test', value)
 
-    # Additional attributes were unset
     @lock.unlock("test")
+    # Checking the values of an attribute are not always immediately available,
+    # so sleep for a second.
+    sleep(1)
     attributes = @lock.send(:item, "test")
+    # Additional attributes were unset
     assert_equal([], attributes)
   end
 end


### PR DESCRIPTION
This allows additional attributes to be set during the lock.  In my use case, we are adding a username attribute, but it can handle any number of attributes.
